### PR TITLE
Added ability to use package.json in different dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,17 @@ jobs:
 The above workflow will create a release that looks like:
 ![Release](release.png)
 
+If your `package.json` isn't available in root, you can pass the directory of the `package.json`:
+
+```yaml
+      - name: Changelog
+        uses: scottbrenner/generate-changelog-action@master
+        id: Changelog
+        env:
+          REPO: ${{ github.repository }}
+        with:
+          package-dir: 'root/to/my/package.json'
+```
+
 For more information, see [actions/create-release: Usage](https://github.com/actions/create-release#usage) and [lob/generate-changelog: Usage](https://github.com/lob/generate-changelog#usage)
 

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,11 @@ author: 'Scott Brenner'
 outputs:
   changelog:
     description: 'Generate changelog'
+inputs:
+  package-dir:
+    description: 'The path for the package.json if it's not in root'
+    required: false
+    default: 'package.json'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,8 @@
 
 git clone --quiet https://github.com/$REPO &> /dev/null
 
-if [ "$1" && "$1" != "package.json" ]; then
-  cp $1 package.json
+if [ "$1" ] && [ "$1" != "package.json" ]; then
+  cp "$1" package.json
 fi
 
 tag=$(git tag --sort version:refname | tail -n 2 | head -n 1)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,10 @@
 
 git clone --quiet https://github.com/$REPO &> /dev/null
 
+if [ "$1" && "$1" != "package.json" ]; then
+  cp $1 package.json
+fi
+
 tag=$(git tag --sort version:refname | tail -n 2 | head -n 1)
 changelog=$(generate-changelog -t "$tag" --file -)
 


### PR DESCRIPTION
Added a parameter which allows to define the directory of the package.json if it's not in root.

The system will work by copying such package.json to the root of the cloned repository inside the action.