### PR TITLE
Build job - run Docker image

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag generate-changelog-action:$(date +%s)
+      run: docker build . --file Dockerfile --tag generate-changelog-action
     
     - name: Docker run
       run: docker run --entrypoint generate-changelog generate-changelog-action --version

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -16,6 +16,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag generate-changelog-action:$(date +%s)
+    
+    - name: Docker run
+      run: docker run --entrypoint generate-changelog generate-changelog-action --version
 
   lint:
     # Name the Job


### PR DESCRIPTION
Adding a step to `build` job in the GitHub Actions workflow for running the Docker image built, checking the version of `generate-changelog` that's installed.