### PR TITLE
Update entrypoint.sh - remove unnecesary repository cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ jobs:
       - name: Changelog
         uses: scottbrenner/generate-changelog-action@master
         id: Changelog
-        env:
-          REPO: ${{ github.repository }}
       - name: Create Release
         id: create_release
         uses: actions/create-release@latest
@@ -55,8 +53,6 @@ If your `package.json` isn't available in root, you can pass the directory of th
       - name: Changelog
         uses: scottbrenner/generate-changelog-action@master
         id: Changelog
-        env:
-          REPO: ${{ github.repository }}
         with:
           package-dir: 'root/to/my/package.json'
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,7 @@
 #!/bin/sh -l
 # shellcheck disable=SC2039
 
-git clone --quiet https://github.com/"$REPO"
-
-if [ "$REPO" = "ScottBrenner/generate-changelog-action" ]; then
-  cd generate-changelog-action || exit
-fi
+git clone --quiet https://github.com/"$REPO" .
 
 if [ "$1" ] && [ "$1" != "package.json" ]; then
   cp "$1" package.json

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,6 @@
 #!/bin/sh -l
 # shellcheck disable=SC2039
 
-git clone --quiet https://github.com/"$REPO" .
-
 if [ "$1" ] && [ "$1" != "package.json" ]; then
   cp "$1" package.json
 fi


### PR DESCRIPTION
Removing an unnecessary/additional repository cloning step in `entrypoint.sh`, closes #19.