### PR TITLE
fix(entrypoint.sh) - generate changelog from previous tag to newest

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,8 +5,9 @@ if [ "$1" ] && [ "$1" != "package.json" ]; then
   cp "$1" package.json
 fi
 
-tag=$(git tag --sort version:refname | tail -n 2 | head -n 1)
-changelog=$(generate-changelog -t "$tag" --file -)
+previous_tag=$(git tag --sort version:refname | tail -n 2 | head -n 1)
+new_tag=$(git tag --sort version:refname | tail -n 1)
+changelog=$(generate-changelog -t "$previous_tag..$new_tag" --file -)
 
 changelog="${changelog//'%'/'%25'}"
 changelog="${changelog//$'\n'/'%0A'}"


### PR DESCRIPTION
Closes https://github.com/ScottBrenner/generate-changelog-action/issues/21
Closes https://github.com/ScottBrenner/generate-changelog-action/issues/16 (?)

From https://github.com/lob/generate-changelog/#cli, updating the `-t` flag in `entrypoint.sh` to generate the changelog from previous tag to newest.