### PR TITLE
feat: Add support for CLI options

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -24,7 +24,7 @@ jobs:
       run: docker run --entrypoint generate-changelog generate-changelog-action --version
 
     - name: Test generating changelog
-      run: docker run -e repo-url="git+https://github.com/ScottBrenner/generate-changelog-action" generate-changelog-action
+      run: docker run -e REPO=${{ github.repository }} generate-changelog-action
 
   lint:
     # Name the Job

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -24,7 +24,7 @@ jobs:
       run: docker run --entrypoint generate-changelog generate-changelog-action --version
 
     - name: Test generating changelog
-      run: docker run -e repo-url="git+https://github.com/ScottBrenner/generate-changelog-action" generate-changelog-action
+      run: docker run -e REPO_URL="git+https://github.com/ScottBrenner/generate-changelog-action" generate-changelog-action
 
   lint:
     # Name the Job

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -24,7 +24,7 @@ jobs:
       run: docker run --entrypoint generate-changelog generate-changelog-action --version
 
     - name: Test generating changelog
-      run: docker run -e REPO_URL="git+https://github.com/ScottBrenner/generate-changelog-action" generate-changelog-action
+      run: docker run -e repo-url="git+https://github.com/ScottBrenner/generate-changelog-action" generate-changelog-action
 
   lint:
     # Name the Job

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -24,7 +24,7 @@ jobs:
       run: docker run --entrypoint generate-changelog generate-changelog-action --version
 
     - name: Test generating changelog
-      run: docker run -e REPO=${{ github.repository }} generate-changelog-action
+      run: docker run -e repo-url="git+https://github.com/ScottBrenner/generate-changelog-action" generate-changelog-action
 
   lint:
     # Name the Job

--- a/README.md
+++ b/README.md
@@ -79,3 +79,4 @@ For more information, see [actions/create-release: Usage](https://github.com/act
 | to-tag                    | "current tag" | The tag to generate changelog up to. If not set, fallbacks to git last tag.   Ex.: v2.0                                       |
 | type                      | Unset         | The type of changelog to generate: patch, minor, or major. If not set, fallbacks to unset.                                    |
 | exclude                   | Unset         | Exclude selected commit types (comma separated). If not set, fallbacks to unset.                                              |
+| allow-unknown             | Unset         | Allow unknown commit types. If not set, fallbacks to unset.                                                                   |

--- a/README.md
+++ b/README.md
@@ -78,3 +78,4 @@ For more information, see [actions/create-release: Usage](https://github.com/act
 | from-tag                  | "last tag"    | The tag to generate changelog from. If not set, fallbacks to git last tag -1. Ex.: v1.0                                       |
 | to-tag                    | "current tag" | The tag to generate changelog up to. If not set, fallbacks to git last tag.   Ex.: v2.0                                       |
 | type                      | Unset         | The type of changelog to generate: patch, minor, or major. If not set, fallbacks to unset.                                    |
+| exclude                   | Unset         | Exclude selected commit types (comma separated). If not set, fallbacks to unset.                                              |

--- a/README.md
+++ b/README.md
@@ -80,4 +80,3 @@ For more information, see [actions/create-release: Usage](https://github.com/act
 | type                      | Unset         | The type of changelog to generate: patch, minor, or major. If not set, fallbacks to unset.                                    |
 | exclude                   | Unset         | Exclude selected commit types (comma separated). If not set, fallbacks to unset.                                              |
 | allow-unknown             | Unset         | Allow unknown commit types. If not set, fallbacks to unset.                                                                   |
-| repo-url                  | package.json  | Specify the repo URL for commit links, defaults to checking the package.json                                                  |

--- a/README.md
+++ b/README.md
@@ -77,3 +77,4 @@ For more information, see [actions/create-release: Usage](https://github.com/act
 | package-dir               | package.json  | The path for the package.json if it is not in root                                                                            |
 | from-tag                  | "last tag"    | The tag to generate changelog from. If not set, fallbacks to git last tag -1. Ex.: v1.0                                       |
 | to-tag                    | "current tag" | The tag to generate changelog up to. If not set, fallbacks to git last tag.   Ex.: v2.0                                       |
+| type                      | Unset         | The type of changelog to generate: patch, minor, or major. If not set, fallbacks to unset.                                    |

--- a/README.md
+++ b/README.md
@@ -80,3 +80,4 @@ For more information, see [actions/create-release: Usage](https://github.com/act
 | type                      | Unset         | The type of changelog to generate: patch, minor, or major. If not set, fallbacks to unset.                                    |
 | exclude                   | Unset         | Exclude selected commit types (comma separated). If not set, fallbacks to unset.                                              |
 | allow-unknown             | Unset         | Allow unknown commit types. If not set, fallbacks to unset.                                                                   |
+| repo-url                  | package.json  | Specify the repo URL for commit links, defaults to checking the package.json                                                  |

--- a/action.yml
+++ b/action.yml
@@ -20,11 +20,10 @@ inputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  args:
-    - ${{ inputs.package-dir }}
   env:
     FROM_TAG: ${{ inputs.from-tag }}
     TO_TAG: ${{ inputs.to-tag }}
+    PACKAGE_DIR: ${{ inputs.package-dir }}
 branding:
   icon: 'edit'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'Allow unknown commit types'
     required: false
     default: ''
+  repo-url:
+    description: 'Specify the repo URL for commit links, defaults to checking the package.json'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -39,6 +43,7 @@ runs:
     TYPE: ${{ inputs.type }}
     EXCLUDE: ${{ inputs.exclude }}
     ALLOW_UNKNOWN: ${{ inputs.allow-unknown }}
+    REPO_URL: ${{ inputs.repo-url }}
 branding:
   icon: 'edit'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -29,10 +29,6 @@ inputs:
     description: 'Allow unknown commit types'
     required: false
     default: ''
-  repo-url:
-    description: 'Specify the repo URL for commit links, defaults to checking the package.json'
-    required: false
-    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -43,7 +39,6 @@ runs:
     TYPE: ${{ inputs.type }}
     EXCLUDE: ${{ inputs.exclude }}
     ALLOW_UNKNOWN: ${{ inputs.allow-unknown }}
-    REPO_URL: ${{ inputs.repo-url }}
 branding:
   icon: 'edit'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,11 @@ inputs:
   type:
     description: 'Type of changelog: patch, minor, or major'
     required: false
-    default: '' 
+    default: ''
+  exclude:
+    description: 'Exclude selected commit types (comma separated)'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -29,6 +33,7 @@ runs:
     FROM_TAG: ${{ inputs.from-tag }}
     TO_TAG: ${{ inputs.to-tag }}
     TYPE: ${{ inputs.type }}
+    EXCLUDE: ${{ inputs.exclude }}
 branding:
   icon: 'edit'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
   to-tag:
     description: 'The tag to generate changelog up to'
     required: false
-    default: ''        
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -17,13 +17,18 @@ inputs:
     description: 'The tag to generate changelog up to'
     required: false
     default: ''
+  type:
+    description: 'Type of changelog: patch, minor, or major'
+    required: false
+    default: '' 
 runs:
   using: 'docker'
   image: 'Dockerfile'
   env:
+    PACKAGE_DIR: ${{ inputs.package-dir }}
     FROM_TAG: ${{ inputs.from-tag }}
     TO_TAG: ${{ inputs.to-tag }}
-    PACKAGE_DIR: ${{ inputs.package-dir }}
+    TYPE: ${{ inputs.type }}
 branding:
   icon: 'edit'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: 'Exclude selected commit types (comma separated)'
     required: false
     default: ''
+  allow-unknown:
+    description: 'Allow unknown commit types'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -34,6 +38,7 @@ runs:
     TO_TAG: ${{ inputs.to-tag }}
     TYPE: ${{ inputs.type }}
     EXCLUDE: ${{ inputs.exclude }}
+    ALLOW_UNKNOWN: ${{ inputs.allow-unknown }}
 branding:
   icon: 'edit'
   color: 'gray-dark'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,10 +58,17 @@ if [ -z "$ALLOW_UKNOWN" ]; then
   echo "Unknown commit types not allowed."
 else
   echo "Allowing unknown commit types."
-  unknown_commits="--allow-unknown "
+  unknown_commits="--allow-unknown"
 fi
 
-changelog=$(generate-changelog "$changelog_type" -t "$previous_tag..$new_tag" "$exclude_types" "$unknown_commits" --file -)
+if [ -z "$REPO_URL" ]; then
+  echo "Repo URL for commit links not specified. Fallbacking to checking the package.json."
+else
+  echo "Repo URL for commit links specified. Using its value."
+  commit_links="--repo-url $REPO_URL"
+fi
+
+changelog=$(generate-changelog "$changelog_type" -t "$previous_tag..$new_tag" "$exclude_types" "$unknown_commits" "$commit_links" --file -)
 
 changelog="${changelog//'%'/'%25'}"
 changelog="${changelog//$'\n'/'%0A'}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,8 +7,11 @@ if [ "$REPO" = "ScottBrenner/generate-changelog-action" ]; then
   cd generate-changelog-action || exit
 fi
 
-if [ "$1" ] && [ "$1" != "package.json" ]; then
-  cp "$1" package.json
+if [ -z "$PACKAGE_DIR" ]; then
+  echo "No path for the package.json passed. Fallbacking to root directory."
+else
+  echo "package-dir detected. Using it's value."
+  cp $PACKAGE_DIR package.json
 fi
 
 if [ -z "$FROM_TAG" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ if [ -z "$PACKAGE_DIR" ]; then
   echo "No path for the package.json passed. Fallbacking to root directory."
 else
   echo "package-dir detected. Using its value."
-  cp $PACKAGE_DIR package.json
+  cp "$PACKAGE_DIR" package.json
 fi
 
 if [ -z "$FROM_TAG" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,24 @@ else
   new_tag=$TO_TAG
 fi
 
-changelog=$(generate-changelog -t "$previous_tag..$new_tag" --file -)
+if [ -z "$TYPE" ]; then
+  echo "No type passed. Fallbacking to unset"
+else
+  echo "Type detected. Using its value."
+  case $TYPE in
+    patch)
+     changelog_type="--patch"
+     ;;
+    minor)
+     changelog_type="--minor"
+     ;;
+    patch)
+     changelog_type="--major"
+     ;;
+  esac
+fi
+
+changelog=$(generate-changelog "$changelog_type" -t "$previous_tag..$new_tag" --file -)
 
 changelog="${changelog//'%'/'%25'}"
 changelog="${changelog//$'\n'/'%0A'}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,17 +58,10 @@ if [ -z "$ALLOW_UKNOWN" ]; then
   echo "Unknown commit types not allowed."
 else
   echo "Allowing unknown commit types."
-  unknown_commits="--allow-unknown"
+  unknown_commits="--allow-unknown "
 fi
 
-if [ -z "$REPO_URL" ]; then
-  echo "Repo URL for commit links not specified. Fallbacking to checking the package.json."
-else
-  echo "Repo URL for commit links specified. Using its value."
-  commit_links="--repo-url $REPO_URL"
-fi
-
-changelog=$(generate-changelog "$changelog_type" -t "$previous_tag..$new_tag" "$exclude_types" "$unknown_commits" "$commit_links" --file -)
+changelog=$(generate-changelog "$changelog_type" -t "$previous_tag..$new_tag" "$exclude_types" "$unknown_commits" --file -)
 
 changelog="${changelog//'%'/'%25'}"
 changelog="${changelog//$'\n'/'%0A'}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,7 @@ else
 fi
 
 if [ -z "$TYPE" ]; then
-  echo "No type passed. Fallbacking to unset"
+  echo "No type passed. Fallbacking to unset."
 else
   echo "Type detected. Using its value."
   case $TYPE in
@@ -47,7 +47,14 @@ else
   esac
 fi
 
-changelog=$(generate-changelog "$changelog_type" -t "$previous_tag..$new_tag" --file -)
+if [ -z "$EXCLUDE" ]; then
+  echo "No commit types selected to exclude. Fallbacking to unset."
+else
+  echo "Commit types selected to exclude. Using its value."
+  exclude_types="--exclude $EXCLUDE"
+fi
+
+changelog=$(generate-changelog "$changelog_type" -t "$previous_tag..$new_tag" "$exclude_types" --file -)
 
 changelog="${changelog//'%'/'%25'}"
 changelog="${changelog//$'\n'/'%0A'}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,7 +54,14 @@ else
   exclude_types="--exclude $EXCLUDE"
 fi
 
-changelog=$(generate-changelog "$changelog_type" -t "$previous_tag..$new_tag" "$exclude_types" --file -)
+if [ -z "$ALLOW_UKNOWN" ]; then
+  echo "Unknown commit types not allowed."
+else
+  echo "Allowing unknown commit types."
+  unknown_commits="--allow-unknown "
+fi
+
+changelog=$(generate-changelog "$changelog_type" -t "$previous_tag..$new_tag" "$exclude_types" "$unknown_commits" --file -)
 
 changelog="${changelog//'%'/'%25'}"
 changelog="${changelog//$'\n'/'%0A'}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ fi
 if [ -z "$PACKAGE_DIR" ]; then
   echo "No path for the package.json passed. Fallbacking to root directory."
 else
-  echo "package-dir detected. Using it's value."
+  echo "package-dir detected. Using its value."
   cp $PACKAGE_DIR package.json
 fi
 
@@ -18,15 +18,15 @@ if [ -z "$FROM_TAG" ]; then
   echo "No from-tag passed. Fallbacking to git previous tag."
   previous_tag=$(git tag --sort version:refname | tail -n 2 | head -n 1)
 else
-  echo "From-tag detected. Using it's value."
+  echo "From-tag detected. Using its value."
   previous_tag=$FROM_TAG
 fi
 
-if [ -z "$TO_TAG"   ]; then
+if [ -z "$TO_TAG" ]; then
   echo "No to-tag passed. Fallbacking to git previous tag."
   new_tag=$(git tag --sort version:refname | tail -n 1)
 else
-  echo "To-tag detected. Using it's value."
+  echo "To-tag detected. Using its value."
   new_tag=$TO_TAG
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,7 +41,7 @@ else
     minor)
      changelog_type="--minor"
      ;;
-    patch)
+    major)
      changelog_type="--major"
      ;;
   esac


### PR DESCRIPTION
Adds support for passing `generate-changelog` 's CLI options - https://github.com/lob/generate-changelog#cli - as input to the Action.

Closes #24 