### PR TITLE
fix(ci): Restore Docker Image CI test job functionality

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,7 @@
 
 # For Docker Image CI test job
 if [ "$REPO" = "ScottBrenner/generate-changelog-action" ]; then
+  git clone --quiet https://github.com/"$REPO"
   cd generate-changelog-action || exit
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/sh -l
 # shellcheck disable=SC2039
 
+# For Docker Image CI test job
+if [ "$REPO" = "ScottBrenner/generate-changelog-action" ]; then
+  cd generate-changelog-action || exit
+fi
+
 if [ "$1" ] && [ "$1" != "package.json" ]; then
   cp "$1" package.json
 fi


### PR DESCRIPTION
Partially reverting https://github.com/ScottBrenner/generate-changelog-action/commit/9141a8160adcdaf769d16c22a35645ea0b60b7a2#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2 to restore Restore Docker Image CI test job functionality.