### PR TITLE
fix(entrypoint.sh): Exclude property

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,7 +61,7 @@ else
   unknown_commits="--allow-unknown "
 fi
 
-changelog=$(generate-changelog "$changelog_type" -t "$previous_tag..$new_tag" ${exclude_types} "$unknown_commits" --file -)
+changelog=$(generate-changelog "$changelog_type" -t "$previous_tag..$new_tag" ${exclude_types} "$unknown_commits" --file -) # shellcheck disable=SC2086
 
 changelog="${changelog//'%'/'%25'}"
 changelog="${changelog//$'\n'/'%0A'}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,7 +61,8 @@ else
   unknown_commits="--allow-unknown "
 fi
 
-changelog=$(generate-changelog "$changelog_type" -t "$previous_tag..$new_tag" ${exclude_types} "$unknown_commits" --file -) # shellcheck disable=SC2086
+# shellcheck disable=SC2086
+changelog=$(generate-changelog "$changelog_type" -t "$previous_tag..$new_tag" ${exclude_types} "$unknown_commits" --file -)
 
 changelog="${changelog//'%'/'%25'}"
 changelog="${changelog//$'\n'/'%0A'}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,7 +61,7 @@ else
   unknown_commits="--allow-unknown "
 fi
 
-changelog=$(generate-changelog "$changelog_type" -t "$previous_tag..$new_tag" "$exclude_types" "$unknown_commits" --file -)
+changelog=$(generate-changelog "$changelog_type" -t "$previous_tag..$new_tag" ${exclude_types} "$unknown_commits" --file -)
 
 changelog="${changelog//'%'/'%25'}"
 changelog="${changelog//$'\n'/'%0A'}"


### PR DESCRIPTION
closes #31

Fixing `--exclude` property functionality via https://github.com/koalaman/shellcheck/wiki/SC2086#exceptions.

Before:
```
$ EXCLUDE=fix,docs FROM_TAG=1.0.0 TO_TAG=v1.3.1 ./entrypoint.sh
...
#### 2021-06-19

##### Documentation Changes

*  update README (#29) (fec5c760)

##### New Features

*  Add support for generate-changelog's CLI options (#27) (21880ba0)
*  adds custom tags values to generate changelog (#26) (b1343188)
* **ci:**
  *  Create release.yml (2d2b1877)
  *  Test generating changelog in Actions workflow (#12) (27337a6e)

##### Bug Fixes

* **Dockerfile:**  Install correct npm package (#33) (73f136c1)
* **ci:**
  *  Restore Docker Image CI test job functionality (#28) (0c61c1f2)
  *  Fix shellcheck failures in entrypoint.sh (#13) (117def4f)
  *  Create empty package.json (ce16f34b)
* **action.yml:**
  *  Fixed missing args for bash shell (#9) (4f38e6d5)
  *  Fixed wrong quote ending (#8) (11714e25)
*  Use tag option (#5) (511d1846)
```

After:
```
$ EXCLUDE=fix,docs FROM_TAG=1.0.0 TO_TAG=v1.3.1 ./entrypoint.sh
...
#### 2021-06-19

##### New Features

*  Add support for generate-changelog's CLI options (#27) (21880ba0)
*  adds custom tags values to generate changelog (#26) (b1343188)
* **ci:**
  *  Create release.yml (2d2b1877)
  *  Test generating changelog in Actions workflow (#12) (27337a6e)
```